### PR TITLE
feat(client): add option for overriding the base url

### DIFF
--- a/src/structures/base.ts
+++ b/src/structures/base.ts
@@ -27,6 +27,11 @@ export interface ClientArgs {
    * @see https://github.com/RasCarlito/axios-cache-adapter
    */
   cacheOptions?: IAxiosCacheAdapterOptions;
+  /**
+   * ## Base URL
+   * Location of the PokéAPI. Leave empty to use the official PokéAPI instance.
+   */
+  baseURL?: string;
 }
 
 /**
@@ -42,7 +47,7 @@ export class BaseClient {
    */
   constructor(clientOptions?: ClientArgs) {
     this.api = setup({
-      baseURL: BaseURL.REST,
+      baseURL: clientOptions?.baseURL ?? BaseURL.REST,
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## Checks and guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [X] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [X] Linting passed `yarn lint:ci`
* [ ] Integration tests added
* [X] Tests passed `yarn test:dev`
* [X] Build passed `yarn build:ci`

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of change

* [ ] Bug fix
* [X] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the changes

In some scenarios, a user might want to use an alternative instance
of the PokéAPI. The `baseURL` option was added to the `ClientArgs`
interface to allow this. If empty, it uses the official PokéAPI as the
default.

No test was added for this feature. Not sure if there's any other public
instance of the PokéAPI to test agains. The beta one seems to be
down.

Fixes #153 