### PR TITLE
fix: otherPokemonSprites field

### DIFF
--- a/src/models/Pokemon/pokemon.ts
+++ b/src/models/Pokemon/pokemon.ts
@@ -222,7 +222,7 @@ export interface OtherPokemonSprites {
   /** Dream World Sprites of this Pokémon */
   dream_world: PokemonVersionSprites;
   /** Official Artwork Sprites of this Pokémon */
-  official_artwork: PokemonVersionSprites;
+  'official-artwork': PokemonVersionSprites;
 }
 
 /** Generation-I Srites */


### PR DESCRIPTION
# Pull Request Template

## Checks and guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [x] Linting passed `yarn lint:ci`
* [ ] Integration tests added
* [x] Tests passed `yarn test:dev`
* [x] Build passed `yarn build:ci`

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the changes
Updated OtherPokemonSprites type interface because it did not match the pokemon API

![image](https://user-images.githubusercontent.com/15928618/140632037-ce476459-c906-4b56-b049-354abaca0ebb.png)
