### PR TITLE
Solving NamedApiResource problem in pokemon-entry

### DIFF
--- a/src/models/Game/pokemon-entry.ts
+++ b/src/models/Game/pokemon-entry.ts
@@ -7,5 +7,5 @@ export interface PokemonEntry {
   /** The index of this Pokémon species entry within the Pokédex */
   entry_number: number;
   /** The Pokémon species being encountered */
-  pokemon_species: NamedAPIResource[];
+  pokemon_species: NamedAPIResource;
 }


### PR DESCRIPTION
# Pull Request Template

## Checks and guidelines

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [ ] Linting passed `yarn lint:ci`
* [ ] Integration tests added
* [ ] Tests passed `yarn test:dev`
* [ ] Build passed `yarn build:ci`

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the changes

* I removed the brackets from species inside Pokemon Entries, this was confliting with the api because the nature of the data