### PR TITLE
Updated documentation links on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ A lightweight Node.js wrapper for the PokéAPI with built-in types. An easy way 
 
 ## Features
 
-- [Bulit-in typings](https://gabb-c.github.io/pokenode-ts/#/typings/berry-typings?id=berries)
-- [Axios with auto-cache requests](https://gabb-c.github.io/pokenode-ts/#/getting-started/cache)
-- [Logging configuration](https://gabb-c.github.io/pokenode-ts/#/getting-started/logs)
+- [Built-in typings](https://pokenode-ts-docs-gabb-c.vercel.app/docs/typings/berry-typings)
+- [Axios with auto-cache requests](https://pokenode-ts-docs-gabb-c.vercel.app/docs/guides/cache)
+- [Logging configuration](https://pokenode-ts-docs-gabb-c.vercel.app/docs/guides/logs)
 
 ## Installation
 
@@ -29,7 +29,7 @@ yarn add pokenode-ts # Recommended
 
 ## Basic Example
 
-Using a client, like [PokemonClient](https://gabb-c.github.io/pokenode-ts/#/clients/pokemon-client):
+Using a client, like [PokemonClient](https://pokenode-ts-docs-gabb-c.vercel.app/docs/clients/pokemon-client):
 
 ```js
 import { PokemonClient } from 'pokenode-ts';


### PR DESCRIPTION
# Pull Request Template

## Checks and guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of change

* [x] Bug fix
* [ ] New feature
* [x] Improvement
* [ ] Breaking change
* [x] Documentation update
* [ ] Security

## Describe the changes

* I've added this because I noticed that some of the links to the documentation in the readme went to the wrong URL. It seems like it was never updated after the site's domain name changed.

* Screenshot, code block, etc... (optional, but helps understanding the changes)
README.md
```
## Features

- [Built-in typings](https://pokenode-ts-docs-gabb-c.vercel.app/docs/typings/berry-typings)
- [Axios with auto-cache requests](https://pokenode-ts-docs-gabb-c.vercel.app/docs/guides/cache)
- [Logging configuration](https://pokenode-ts-docs-gabb-c.vercel.app/docs/guides/logs)

## Installation

bash
npm i pokenode-ts
# or
yarn add pokenode-ts # Recommended


## Basic Example

Using a client, like [PokemonClient](https://pokenode-ts-docs-gabb-c.vercel.app/docs/clients/pokemon-client):
```
