### PR TITLE
Add past damage relations to Pokemon/Type

### DIFF
--- a/docs/src/typings/pokemon-typings.md
+++ b/docs/src/typings/pokemon-typings.md
@@ -831,6 +831,19 @@ export interface TypeRelations {
 }
 ```
 
+## Type Relations
+
+Details of how effective this type was toward others and vice versa in a previous generation
+
+```ts
+export interface TypeRelationsPast {
+  /** The last generation in which the referenced type had the listed damage relations */
+  generation: NamedAPIResource;
+  /** The damage relations the referenced type had up to and including the listed generation */
+  damage_relations: TypeRelations;
+}
+```
+
 ## Type
 
 Types are properties for Pokémon and their moves.
@@ -845,6 +858,8 @@ export interface Type {
   name: string;
   /** A detail of how effective this type is toward others and vice versa */
   damage_relations: TypeRelations;
+  /** A list of details of how effective this type was toward others and vice versa in previous generations */
+  past_damage_relations: TypeRelationsPast[];
   /** A list of game indices relevent to this item by generation */
   game_indices: GenerationGameIndex[];
   /** The generation this type was introduced in */

--- a/src/models/Pokemon/type.ts
+++ b/src/models/Pokemon/type.ts
@@ -29,6 +29,16 @@ export interface TypeRelations {
 }
 
 /**
+ * Details of how effective this type was toward others and vice versa in a previous generation
+ */
+export interface TypeRelationsPast {
+  /** The last generation in which the referenced type had the listed damage relations */
+  generation: NamedAPIResource;
+  /** The damage relations the referenced type had up to and including the listed generation */
+  damage_relations: TypeRelations;
+}
+
+/**
  * ## Type
  * Types are properties for Pokémon and their moves.
  * Each type has three properties: which types of Pokémon it is super effective against,
@@ -41,6 +51,8 @@ export interface Type {
   name: string;
   /** A detail of how effective this type is toward others and vice versa */
   damage_relations: TypeRelations;
+  /** A list of details of how effective this type was toward others and vice versa in previous generations */
+  past_damage_relations: TypeRelationsPast[];
   /** A list of game indices relevent to this item by generation */
   game_indices: GenerationGameIndex[];
   /** The generation this type was introduced in */


### PR DESCRIPTION
# Pull Request Template

## Checks and guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [x] Linting passed `lint and lint:tsc`
* [ ] Tests added (if needed)
* [x] Tests passed `test:dev`
* [x] Build passed `build`

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the changes

I've added the past_damage_relations to the Type interface (and a TypeRelationsPast interface), as described in the api-documentation (https://pokeapi.co/docs/v2#types)