### PR TITLE
Add Showdown animated sprites

### DIFF
--- a/src/models/Pokemon/pokemon.ts
+++ b/src/models/Pokemon/pokemon.ts
@@ -198,6 +198,8 @@ export interface OtherPokemonSprites {
   "official-artwork": OfficialArtwork;
   /** Home Artwork Sprites of this Pokémon */
   home: Home;
+  /** Pokemon Showdown animated sprites of this Pokémon */
+  showdown: Showdown;
 }
 
 /** Dream World sprites */
@@ -209,7 +211,7 @@ export interface DreamWorld {
 }
 
 /** Official Artwork sprites */
-interface OfficialArtwork {
+export interface OfficialArtwork {
   /** The default depiction of this Pokémon from the front in battle */
   front_default: string | null;
 }
@@ -222,8 +224,28 @@ export interface Home {
   front_female: string | null;
   /** The shiny depiction of this Pokémon from the front in battle */
   front_shiny: string | null;
-  /** The shiny female depiction of this Pokémon from the back in battle */
+  /** The shiny female depiction of this Pokémon from the front in battle */
   front_shiny_female: string | null;
+}
+
+/** Showdown Sprites */
+export interface Showdown {
+  /** The default depiction of this Pokémon from the front in battle */
+  front_default: string | null;
+  /** The female depiction of this Pokémon from the front in battle */
+  front_female: string | null;
+  /** The shiny depiction of this Pokémon from the front in battle */
+  front_shiny: string | null;
+  /** The shiny female depiction of this Pokémon from the front in battle */
+  front_shiny_female: string | null;
+  /** The default depiction of this Pokémon from the back in battle */
+  back_default: string | null;
+  /** The female depiction of this Pokémon from the back in battle */
+  back_female: string | null;
+  /** The shiny depiction of this Pokémon from the back in battle */
+  back_shiny: string | null;
+  /** The shiny female depiction of this Pokémon from the back in battle */
+  back_shiny_female: string | null;
 }
 
 /** Generation-I Srites */
@@ -310,7 +332,7 @@ export interface Gold {
 }
 
 /** Silver sprites */
-interface Silver {
+export interface Silver {
   /** The default depiction of this Pokémon from the back in battle */
   back_default: string | null;
   /** The shiny depiction of this Pokémon from the back in battle */


### PR DESCRIPTION
# Pull Request Template

## Checks and Guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [x] Linting passed (`lint` and `lint:tsc`)
* [ ] Tests added (if needed)
* [x] Tests passed (`test:dev`)
* [x] Build passed (`build`)

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the Changes

I've added this because Pokemon Showdown sprite support was missing. I also added `export` to the other interfaces in that file for consistency.