### PR TITLE
docs: add PokemonCries documentation to align TS types and docs

### DIFF
--- a/docs/src/typings/pokemon-typings.md
+++ b/docs/src/typings/pokemon-typings.md
@@ -39,6 +39,8 @@ export interface Pokemon {
    * A visual representation of the various sprites can be found at [PokeAPI/sprites](https://github.com/PokeAPI/sprites#sprites)
    */
   sprites: PokemonSprites;
+  /** A set of cries used to depict this Pokémon in the game. */
+  cries: PokemonCries;
   /** The species this Pokémon belongs to */
   species: NamedAPIResource;
   /** A list of base stat values for this Pokémon */
@@ -46,6 +48,19 @@ export interface Pokemon {
   /** A list of details showing types this Pokémon has */
   types: PokemonType[];
 }
+```
+
+## Pokemon Cries
+
+Cries used to depict this Pokémon in the game.
+
+```ts
+export type PokemonCries = {
+  /** The legacy depiction of this Pokémon's cry. */
+  legacy: string;
+  /** The latest depiction of this Pokémon's cry. */
+  latest: string;
+};
 ```
 
 > Check out [Bulbapedia](<https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_(species)>) for greater detail.


### PR DESCRIPTION
# Pull Request Template

## Checks and Guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [x] Documentation update
* [ ] Security

## Describe the Changes

I have updated the pokemon-typing documentation to include `Cries`
