### PR TITLE
fix(pokemon): add `order` in `PokemonMove`

### DIFF
--- a/src/models/Pokemon/pokemon.ts
+++ b/src/models/Pokemon/pokemon.ts
@@ -124,6 +124,8 @@ export interface PokemonMove {
   move: NamedAPIResource;
   /** The details of the version in which the Pokémon can learn the move */
   version_group_details: PokemonMoveVersion[];
+  /** Order by which the pokemon will learn the move. A newly learnt move will replace the move with lowest order */
+  order: number | null;
 }
 
 /**


### PR DESCRIPTION
# Pull Request Template

## Checks and Guidelines
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [x] Linting passed (`lint` and `lint:tsc`)
* [x] Tests added (if needed)
* [x] Tests passed (`test:dev`)
* [x] Build passed (`build`)

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the Changes

* I've added this because it's missing. The docs state this property as `integer`, but in the data (e.g. Bulbasaur) it's seen as `number | null`.

* **Tests Information:**
  - [ ] Unit tests added and passed
  - [ ] Integration tests added and passed

* see: https://pokeapi.co/docs/v2#pokemonmoveversion
