### PR TITLE
fix: added missing 'front_shiny' to 'official artwork' in the pokemon model

### DIFF
--- a/src/models/Pokemon/pokemon.ts
+++ b/src/models/Pokemon/pokemon.ts
@@ -221,6 +221,8 @@ export interface DreamWorld {
 export interface OfficialArtwork {
   /** The default depiction of this Pokémon from the front in battle */
   front_default: string | null;
+  /** The shiny depiction of this Pokémon from the front in battle */
+  front_shiny: string | null;
 }
 
 /** Home sprites */


### PR DESCRIPTION
This is my first ever pull request or contribution to any code! I may have done some things wrong. 

###PR

* [X] Have you checked that there aren't other open [Pull Requests](https://github.com/Gabb-c/pokenode-ts/pulls) for the same update/change?
* [X] Linting passed (`lint` and `lint:tsc`)
* [ ] Tests added (if needed)
* [X] Tests passed (`test:dev`) *See Note below
* [X] Build passed (`build`) *See Note below

This was the result from my test but I didn't mess with any Pokemon moves or anything:
```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/move/move.spec.ts > Move Client > check if it returns a move category passing a name
 FAIL  tests/move/move.spec.ts > Move Client > check if it returns a move category passing a name
 FAIL  tests/move/move.spec.ts > Move Client > check if it returns a move category passing a name
 FAIL  tests/move/move.spec.ts > Move Client > check if it returns a move category passing a name
AxiosError: Request failed with status code 400
 ❯ settle node_modules/axios/lib/core/settle.js:19:12
 ❯ IncomingMessage.handleStreamEnd node_modules/axios/lib/adapters/http.js:599:11
 ❯ Axios.request node_modules/axios/lib/core/Axios.js:45:41
 ❯ MoveClient.getResource src/clients/base.ts:75:7
     73|   protected async getResource<T>(endpoint: string, identifier?: string | number): Promise<T> {
     74|     return (
     75|       await this.api.get<T>(`${endpoint}/${identifier || identifier === 0 ? identifier : ""}`)
       |       ^
     76|     ).data;
     77|   }
 ❯ tests/move/move.spec.ts:89:18

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯


 Test Files  1 failed | 12 passed (13)
      Tests  1 failed | 177 passed (178)
   Start at  17:32:19
   Duration  28.98s (transform 377ms, setup 2.72s, collect 2.89s, tests 103.12s, environment 2ms, prepare 2.14s)

 FAIL  Tests failed. Watching for file changes...
       press h to show help, press q to quit
Cancelling test run. Press CTRL+c again to exit forcefully.
```

This is the result of my build:
```
> pokenode-ts@1.19.0 build
> tsup --config tsup.config.ts && size-limit

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.0
CLI Using tsup config: D:\Contributions\pokenode-ts\tsup.config.ts
CLI Target: esnext
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM lib\index.js     52.38 KB
ESM lib\index.js.map 104.74 KB
ESM ⚡️ Build success in 129ms
CJS lib\index.cjs     54.62 KB
CJS lib\index.cjs.map 27.95 KB
CJS ⚡️ Build success in 131ms
DTS Build start
src/clients/base.ts(60,7): error TS2345: Argument of type '(response: CacheAxiosResponse) => CacheAxiosResponse<any, any>' is not assignable to parameter of type '(value: Partial<CacheAxiosResponse<unknown, unknown>> & AxiosResponse<unknown, unknown>) => (Partial<CacheAxiosResponse<unknown, unknown>> & AxiosResponse<...>) | Promise<...>'.
  Types of parameters 'response' and 'value' are incompatible.
    Type 'Partial<CacheAxiosResponse<unknown, unknown>> & AxiosResponse<unknown, unknown>' is not assignable to type 'CacheAxiosResponse<any, any>'.
      Types of property 'id' are incompatible.
        Type 'string | undefined' is not assignable to type 'string'.     
          Type 'undefined' is not assignable to type 'string'.

us> (node:internal/per_context/messageport:23:28)
DTS Build error
```

*Despite those errors, when I linked this to my react native project, the red squiggly went away!*

## Type of Change

* [X] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] Documentation update
* [ ] Security

## Describe the Changes

* I've added this because I would get an error (red squiggly) when using `pokemon.sprites.other?.['official-artwork']?.front_shiny`
'Property 'front_shiny' does not exist on type 'OfficialArtwork'.'

This actually compiles and works just fine without the fix. I'd like the squiggly to go away though. Lol.

You can find pokenode-ts being used at my site/app, PokePage.app. Please feel free to check it out and thanks for this package! I was already using pokeapi and stumbled upon your wrapper. 