### PR TITLE
fix(constants): add protect move ailment

### DIFF
--- a/src/constants/moves.ts
+++ b/src/constants/moves.ts
@@ -21,6 +21,7 @@ export const MOVE_AILMENTS = {
   INGRAIN: 21,
   SILENCE: 24,
   TAR_SHOT: 42,
+  PROTECT: 43,
 } as const;
 
 export const MOVE_BATTLE_STYLES = {

--- a/src/models/pokemon/pokemon.ts
+++ b/src/models/pokemon/pokemon.ts
@@ -362,6 +362,8 @@ export interface GenerationIISprites {
 
 /** Crystal sprites. */
 export interface Crystal {
+  /** The animated sprites of this Pokémon. */
+  animated: CrystalAnimated;
   /** The default depiction of this Pokémon from the back in battle. */
   back_default: string | null;
   /** The shiny depiction of this Pokémon from the back in battle. */
@@ -378,6 +380,14 @@ export interface Crystal {
   front_shiny_transparent: string | null;
   /** The transparent depiction of this Pokémon from the front in battle. */
   front_transparent: string | null;
+}
+
+/** Animated Crystal sprites. */
+export interface CrystalAnimated {
+  /** The default depiction of this Pokémon from the front in battle. */
+  front_default: string | null;
+  /** The shiny depiction of this Pokémon from the front in battle. */
+  front_shiny: string | null;
 }
 
 /** Gold sprites of this Pokémon. */
@@ -524,6 +534,8 @@ export interface Platinum {
 export interface GenerationVSprites {
   /** Black-white sprites of this Pokémon. */
   "black-white": BlackWhite;
+  /** Menu icons of this Pokémon. */
+  icons: GenerationVIcons;
 }
 
 /** Black/White sprites. */
@@ -565,6 +577,20 @@ export interface Animated {
   front_female: string | null;
   /** The shiny female depiction of this Pokémon from the back in battle. */
   front_shiny_female: string | null;
+}
+
+/** Generation-V menu icons. */
+export interface GenerationVIcons {
+  /** The animated menu icon of this Pokémon. */
+  animated: GenerationVAnimatedIcons;
+  /** The menu icon of this Pokémon. */
+  front_default: string | null;
+}
+
+/** Animated Generation-V menu icons. */
+export interface GenerationVAnimatedIcons {
+  /** The animated menu icon of this Pokémon. */
+  front_default: string | null;
 }
 
 /** Generation-VI Sprites. */
@@ -745,6 +771,8 @@ export interface PokemonForm {
    * having a specific ability. Empty for forms that are not triggered.
    */
   trigger_conditions: PokemonFormCondition[];
+  /** The flavor text of this Pokémon form, in every language it is published in. */
+  flavor_text_entries: FlavorText[];
 }
 
 /** A condition that causes a Pokémon to take on a particular form. */

--- a/tests/helpers/model-keys.ts
+++ b/tests/helpers/model-keys.ts
@@ -41,6 +41,7 @@ export interface Models {
   ContestName: M.ContestName;
   ContestType: M.ContestType;
   Crystal: M.Crystal;
+  CrystalAnimated: M.CrystalAnimated;
   Currency: M.Currency;
   Description: M.Description;
   DiamondPearl: M.DiamondPearl;
@@ -78,6 +79,8 @@ export interface Models {
   GenerationVIITypeSprites: M.GenerationVIITypeSprites;
   GenerationVISprites: M.GenerationVISprites;
   GenerationVITypeSprites: M.GenerationVITypeSprites;
+  GenerationVAnimatedIcons: M.GenerationVAnimatedIcons;
+  GenerationVIcons: M.GenerationVIcons;
   GenerationVSprites: M.GenerationVSprites;
   GenerationVTypeSprites: M.GenerationVTypeSprites;
   GenerationViiIcons: M.GenerationViiIcons;

--- a/tests/live/drift.live.spec.ts
+++ b/tests/live/drift.live.spec.ts
@@ -407,6 +407,7 @@ const SPRITES: Case[] = [
   caseFor("Yellow", async () => (await generationISprites()).yellow),
   caseFor("GenerationIISprites", generationIISprites),
   caseFor("Crystal", async () => (await generationIISprites()).crystal),
+  caseFor("CrystalAnimated", async () => (await generationIISprites()).crystal.animated),
   caseFor("Gold", async () => (await generationIISprites()).gold),
   caseFor("Silver", async () => (await generationIISprites()).silver),
   caseFor("GenerationIIISprites", generationIIISprites),
@@ -420,6 +421,8 @@ const SPRITES: Case[] = [
   caseFor("GenerationVSprites", generationVSprites),
   caseFor("BlackWhite", blackWhiteSprites),
   caseFor("Animated", async () => (await blackWhiteSprites()).animated),
+  caseFor("GenerationVIcons", async () => (await generationVSprites()).icons),
+  caseFor("GenerationVAnimatedIcons", async () => (await generationVSprites()).icons.animated),
   caseFor("GenerationVISprites", generationVISprites),
   caseFor(
     "OmegarubyAlphasapphire",


### PR DESCRIPTION
The weekly drift tier went red: 4 failed / 230 passed on `pnpm test:live`. Each failure is upstream
adding something `src/models` / `src/constants` does not declare.

| Failing test | Wire | We declared |
| --- | --- | --- |
| `constants` › `MOVE_AILMENTS` | `move-ailment/43` = `protect` | map stopped at `tar-shot: 42` |
| `drift` › `PokemonForm` | has `flavor_text_entries` | absent |
| `drift` › sprite `Crystal` | has `animated: { front_default, front_shiny }` | absent |
| `drift` › sprite `GenerationVSprites` | has `icons: { animated: { front_default }, front_default }` | only `black-white` |

## Changes

- `MOVE_AILMENTS.PROTECT: 43`.
- `PokemonForm.flavor_text_entries: FlavorText[]` — the existing `FlavorText` is reused, not a new type.
- `Crystal.animated: CrystalAnimated` (new), `GenerationVSprites.icons: GenerationVIcons` (new, with
  `GenerationVAnimatedIcons`). All values `string | null`, all keys required.
- Three new `SPRITES` rows in `drift.live.spec.ts` plus their `Models` entries, so the new shapes are
  watched rather than assumed.

## How the shapes were established

- `move-ailment/43` fetched directly: `{"id":43,"name":"protect",...}`.
- `pokemon/{1,4,25,133,151,172,249,386,900,1000}` sampled: `crystal.animated` is always exactly
  `{front_default, front_shiny}` and `generation-v.icons` always exactly
  `{animated:{front_default}, front_default}`. Keys are never absent; values are `null` for species
  predating the game, which is what makes them required-and-nullable rather than optional.
- `pokemon-form.flavor_text_entries` is `[]` on every form sampled (15 ids), so the element shape
  cannot come off the wire. `PokemonFormFlavorTextSerializer` in PokeAPI's `pokemon_v2/serializers.py`
  settles it as `("flavor_text", "language", "version")` — exactly the existing `FlavorText`.

## Verification

`biome ci` clean · `tsc --noEmit` clean on root, `tests`, and `docs/.vitepress` · unit 495 passed ·
**live 237 passed / 237** · `tsdown` built ESM + CJS + types.

Note: `publint`/`attw` did not run — `tsdown`'s pack step shells out to `pnpm`, which is currently
broken on the machine this was prepared on (`pnpm --version` errors `unable to open database file`).
CI is unaffected.
